### PR TITLE
change prepop -> formal due inaccurate result

### DIFF
--- a/testperformance.bat
+++ b/testperformance.bat
@@ -19,4 +19,4 @@ echo Makesure your power mode on performance mode
 pause
 echo off
 cls
-winsat prepop
+winsat formal


### PR DESCRIPTION
winsat prepop will valid with all mode even-though the battery mode. The battery mode will result inaccurate for laptop users. So i change to winsat formal.